### PR TITLE
Add $schema to ecs.json and .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+$schema: https://json.schemastore.org/circleciconfig#
 version: 2
 jobs:
   test:


### PR DESCRIPTION
Having a $schema in json files has a bunch of benefits, mostly because of language servers (json-languages-server and yaml-language-server). These are automatically setup in VSCode and easy to set up for other editors.

1. You get auto-completion through your LSP. This way, you don't make typo's and you don't have to type as much.
1. You get documentation about some properties through your LSP in your editor. Just hover over a field.
1. You get lint errors in your editor if you add a field that doesn't exist (and additionalProperties are forbidden) or if you have the type wrong
1. In the future, we might enforce the schema of ecs.json files through a CircleCI job

Result of linting ecs.json files for this repo:
```

```

Note that healtCheck is now a required property, if you have a containerPort defined. See https://datacamp.atlassian.net/wiki/spaces/PRODENG/pages/25690481/ecs.json+reference for more info.
Note that you might have a literal "${VARIABLE}" in you ecs.json that still gets replaced at build time to create a valid ecs.jon which might complain in your editor but is not shown above
